### PR TITLE
Improve nullability annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pyvenv.cfg
 **/*.egg-info/*
 generation/bin/*
 generation/dist
+.DS_Store

--- a/LocalizedStringKit/LocalizedStringKit.xcodeproj/project.pbxproj
+++ b/LocalizedStringKit/LocalizedStringKit.xcodeproj/project.pbxproj
@@ -78,8 +78,8 @@
 		DDF2F98523DF3FA400B7E8E9 /* LocalizedStringKit */ = {
 			isa = PBXGroup;
 			children = (
-				DDF2F99D23DF401600B7E8E9 /* LocalizedStringKit.m */,
 				DDF2F98623DF3FA400B7E8E9 /* LocalizedStringKit.h */,
+				DDF2F99D23DF401600B7E8E9 /* LocalizedStringKit.m */,
 				DDF2F98723DF3FA400B7E8E9 /* Info.plist */,
 			);
 			path = LocalizedStringKit;

--- a/LocalizedStringKit/LocalizedStringKit/LocalizedStringKit.h
+++ b/LocalizedStringKit/LocalizedStringKit/LocalizedStringKit.h
@@ -4,6 +4,8 @@
 
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 //! Project version number for LocalizedStringKit.
 FOUNDATION_EXPORT double LocalizedStringKitVersionNumber;
 
@@ -14,7 +16,7 @@ FOUNDATION_EXPORT const unsigned char LocalizedStringKitVersionString[];
 ///
 /// The `value` should be the English string and the `comment` should give context on where the string is used.
 /// Ex: `Localized("Cancel", "Action sheet action title")
-NSString * _Nonnull Localized(NSString * _Nonnull value, NSString * _Nonnull comment);
+NSString *Localized(NSString *value, NSString *comment);
 
 /// Additional localization function used to localize strings
 ///
@@ -24,11 +26,13 @@ NSString * _Nonnull Localized(NSString * _Nonnull value, NSString * _Nonnull com
 ///
 /// Ex: `LocalizedWithKeyExtension("Archive", "Button title", "Archive action")
 /// Ex: `LocalizedWithKeyExtension("Archive", "Folder title", "Archive folder")
-NSString * _Nonnull LocalizedWithKeyExtension(NSString * _Nonnull value, NSString * _Nonnull comment, NSString * _Nonnull keyExtension);
+NSString *LocalizedWithKeyExtension(NSString *value, NSString *comment, NSString *keyExtension);
 
 /// Marks a string as not needing localization (to avoid false positives from
 /// the static analyzer
-NSString * _Nonnull LocalizationUnnecessary(NSString * _Nonnull value);
+NSString *LocalizationUnnecessary(NSString *value);
 
 /// Load the bundle which contains the localized strings
 NSBundle * _Nullable getLocalizedStringKitBundle(void);
+
+NS_ASSUME_NONNULL_END

--- a/LocalizedStringKit/LocalizedStringKit/LocalizedStringKit.m
+++ b/LocalizedStringKit/LocalizedStringKit/LocalizedStringKit.m
@@ -12,20 +12,20 @@
 
 @implementation LocalizedStringKit
 
-NSString * _Nonnull Localized(NSString * _Nonnull value, NSString * _Nonnull comment) {
+NSString *Localized(NSString *value, NSString *comment) {
   return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:nil];
 }
 
-NSString * _Nonnull LocalizedWithKeyExtension(NSString * _Nonnull value, NSString * _Nonnull comment, NSString * _Nonnull keyExtension) {
+NSString *LocalizedWithKeyExtension(NSString *value, NSString *comment, NSString *keyExtension) {
   return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:keyExtension];
 }
 
 __attribute__((annotate("returns_localized_nsstring")))
-NSString * _Nonnull LocalizationUnnecessary(NSString * _Nonnull value) {
+NSString *LocalizationUnnecessary(NSString *value) {
   return value;
 }
 
-NSBundle * _Nullable getLocalizedStringKitBundle() {
+NSBundle *getLocalizedStringKitBundle() {
   return [LocalizedStringKit getLocalizedStringKitBundle];
 }
 


### PR DESCRIPTION
1. Use nonnull macro to remove redundant annotations in header file
2. Remove annotations in .m file since its no use in implementation