### PR TITLE
Add tableName support for string segmentation

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/LocalizedStringKit.xcodeproj/project.pbxproj
+++ b/LocalizedStringKit.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		OBJ_15 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
 		OBJ_25 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		OBJ_9 /* LocalizedStringKit.m */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = LocalizedStringKit.m; sourceTree = "<group>"; tabWidth = 2; };
+		OBJ_9 /* LocalizedStringKit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LocalizedStringKit.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/LocalizedStringKit.xcodeproj/project.pbxproj
+++ b/LocalizedStringKit.xcodeproj/project.pbxproj
@@ -30,6 +30,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		83988616250937B700A0FE95 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "LocalizedStringKit::LocalizedStringKitTests";
+			remoteInfo = LocalizedStringKitTests;
+		};
 		DD3C4FFF24B8B50C00A83BC2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
@@ -47,7 +54,7 @@
 		OBJ_15 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
 		OBJ_25 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		OBJ_9 /* LocalizedStringKit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LocalizedStringKit.m; sourceTree = "<group>"; };
+		OBJ_9 /* LocalizedStringKit.m */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = LocalizedStringKit.m; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,7 +111,7 @@
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -113,7 +120,6 @@
 				OBJ_16 /* Products */,
 				OBJ_25 /* README.md */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_7 /* Sources */ = {
@@ -212,7 +218,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_16 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -257,7 +263,7 @@
 		OBJ_46 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "LocalizedStringKit::LocalizedStringKitTests" /* LocalizedStringKitTests */;
-			targetProxy = "LocalizedStringKit::LocalizedStringKitTests" /* LocalizedStringKitTests */;
+			targetProxy = 83988616250937B700A0FE95 /* PBXContainerItemProxy */;
 		};
 		OBJ_56 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ For any issues, refer to the Carthage documentation.
 
 ### Strings bundle
 
-The app and the library need to be able to access the strings bundle. To do this we are going to do some basic setup:
+The app and the library need to be able to access the strings bundle(s). To do this we are going to do some basic setup:
+
+#### Primary Bundle
 
 1. Create a folder in your app project somewhere named `LocalizedStringKit`.
 2. Inside that folder, create a new folder named `LocalizedStringKit.bundle` (this will turn it into a bundle).
@@ -40,6 +42,15 @@ ProjectName/
 ├── LocalizedStringKit/
 |   ├── LocalizedStringKit.bundle/
 ```
+
+#### Secondary Bundle(s): tableNames
+
+To leverage the tableName segmentation of strings in multiple bundles, you'll need to create these bundles as well.
+
+1. Navigate to the first `LocalizedStringKit` folder that was created in the Primary set up.
+2. Inside that folder, create a new folder named `<tableName>.bundle` (this will turn it into a bundle). Make sure to replace `tableName` with the case sensitive tableName you will use in your source.
+3. Add this bundle to your project in Xcode
+4. Ensure that this bundle is copied to your main app bundle (even if you are going to be using it in a framework).
 
 ### Creating some new strings
 

--- a/Sources/LocalizedStringKit/LocalizedStringKit.m
+++ b/Sources/LocalizedStringKit/LocalizedStringKit.m
@@ -121,7 +121,6 @@ NSBundle *getLocalizedStringKitBundle(NSString *_Nullable tableName) {
     }
 
     NSURL *newPath = [[searchPath URLByAppendingPathComponent:@".."] absoluteURL];
-    
     if ([newPath isEqual:searchPath])
     {
       break;

--- a/Sources/LocalizedStringKit/LocalizedStringKit.m
+++ b/Sources/LocalizedStringKit/LocalizedStringKit.m
@@ -109,7 +109,8 @@ NSBundle *getLocalizedStringKitBundle(NSString *_Nullable tableName) {
     // Defaults to primary bundle if tableName not specified
     tableName = @"LocalizedStringKit.bundle";
   }
-  else {
+  else
+  {
     // Append suffix
     tableName = [tableName stringByAppendingFormat:@".bundle"];
   }

--- a/Sources/LocalizedStringKit/LocalizedStringKit.m
+++ b/Sources/LocalizedStringKit/LocalizedStringKit.m
@@ -12,12 +12,14 @@
 
 @implementation LocalizedStringKit
 
-NSString *Localized(NSString *value, NSString *comment) {
-  return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:nil];
+#pragma mark - Public
+
+NSString *Localized(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nullable tableName) {
+  return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:nil tableName:tableName];
 }
 
-NSString *LocalizedWithKeyExtension(NSString *value, NSString *comment, NSString *keyExtension) {
-  return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:keyExtension];
+NSString *LocalizedWithKeyExtension(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nonnull keyExtension, NSString *_Nullable tableName) {
+  return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:keyExtension tableName:tableName];
 }
 
 __attribute__((annotate("returns_localized_nsstring")))
@@ -25,25 +27,40 @@ NSString *LocalizationUnnecessary(NSString *value) {
   return value;
 }
 
-NSBundle *getLocalizedStringKitBundle() {
-  return [LocalizedStringKit getLocalizedStringKitBundle];
+NSBundle *getLocalizedStringKitBundle(NSString *_Nullable tableName) {
+  return [LocalizedStringKit getLocalizedStringKitBundle:tableName];
 }
 
-+ (NSString *)localizeWithValue:(NSString *)value comment:(NSString *)comment keyExtension:(NSString *)keyExtension
+#pragma mark - Private / Static
+
++ (NSString *)localizeWithValue:(NSString *_Nonnull)value comment:(NSString *_Nonnull)comment keyExtension:(NSString *_Nullable)keyExtension tableName:(NSString *_Nullable)tableName
 {
   // Key
   NSString *key = [self keyWithValue:value keyExtension:keyExtension];
 
-  // Table
+  // Table: This does not change between bundles
   NSString *table = @"LocalizedStringKit";
 
-  // Bundle
-  static NSBundle *bundle = nil;
+  // Bundle Map: [tableName String: NSBundle]
+  static NSMutableDictionary<NSString *, NSBundle *> *bundleMap = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    bundleMap = [[NSMutableDictionary alloc] init];
+  });
+
+  if (tableName == nil)
+  {
+    // Default to primary strings bundle
+    tableName = @"LocalizedStringKit.bundle";
+  }
+
+  NSBundle *bundle = [bundleMap objectForKey:tableName];
 
   if (bundle == nil)
   {
-    // Load cached reference ot `LocalizedStringKit` bundle
-    bundle = [LocalizedStringKit getLocalizedStringKitBundle];
+    // Load and cache bundle
+    bundle = [LocalizedStringKit getLocalizedStringKitBundle:tableName];
+    [bundleMap setObject:bundle forKey:tableName];
   }
 
   if (bundle == nil)
@@ -56,7 +73,7 @@ NSBundle *getLocalizedStringKitBundle() {
   return NSLocalizedStringWithDefaultValue(key, table, bundle, value, comment);
 }
 
-+ (NSString *)keyWithValue:(NSString *)value keyExtension:(NSString *)keyExtension
++ (NSString *)keyWithValue:(NSString *_Nonnull)value keyExtension:(NSString *)keyExtension
 {
   // Generate the `key` which is equal to the `MD5(<value>)` or `MD5(<value>:<keyExtension>)`. This logic must stay in sync with `localize.py`.
   NSString *hashInput = value;
@@ -80,13 +97,22 @@ NSBundle *getLocalizedStringKitBundle() {
   return key;
 }
 
-+ (NSBundle *)getLocalizedStringKitBundle
++ (NSBundle *)getLocalizedStringKitBundle:(NSString *_Nullable)tableName
 {
   NSURL *searchPath = [[NSBundle mainBundle] bundleURL];
 
+  if (tableName == nil) {
+    // Defaults to primary bundle if tableName not specified
+    tableName = @"LocalizedStringKit.bundle";
+  }
+  else {
+    // Append suffix
+    tableName = [tableName stringByAppendingFormat:@".bundle"];
+  }
+
   while(YES)
   {
-    NSURL *bundleURL = [searchPath URLByAppendingPathComponent:@"LocalizedStringKit.bundle"];
+    NSURL *bundleURL = [searchPath URLByAppendingPathComponent:tableName];
     NSBundle *bundle = [NSBundle bundleWithURL:bundleURL];
 
     if (bundle)
@@ -95,7 +121,7 @@ NSBundle *getLocalizedStringKitBundle() {
     }
 
     NSURL *newPath = [[searchPath URLByAppendingPathComponent:@".."] absoluteURL];
-
+    
     if ([newPath isEqual:searchPath])
     {
       break;

--- a/Sources/LocalizedStringKit/LocalizedStringKit.m
+++ b/Sources/LocalizedStringKit/LocalizedStringKit.m
@@ -14,7 +14,11 @@
 
 #pragma mark - Public
 
-NSString *Localized(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nullable tableName) {
+NSString *Localized(NSString *_Nonnull value, NSString *_Nonnull comment) {
+  return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:nil tableName:nil];
+}
+
+NSString *LocalizedWithTable(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nonnull tableName) {
   return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:nil tableName:tableName];
 }
 

--- a/Sources/LocalizedStringKit/include/LocalizedStringKit.h
+++ b/Sources/LocalizedStringKit/include/LocalizedStringKit.h
@@ -14,25 +14,34 @@ FOUNDATION_EXPORT const unsigned char LocalizedStringKitVersionString[];
 
 /// Primary localization function used to localize strings
 ///
-/// The `value` should be the English string and the `comment` should give context on where the string is used.
-/// Ex: `Localized("Cancel", "Action sheet action title")
-NSString *Localized(NSString *value, NSString *comment);
+/// @param value: The English string
+/// @param comment: String to give context where the value string is used
+/// @param tableName: Optional string to provide additional classification of the value string. Can be used to segment groups of strings in multiple bundles.
+///
+/// Examples
+/// Localized("Cancel", "Action sheet action title", nil)
+/// Localized("Cancel", "Action sheet action title", "primary")
+/// Localized("Cancel", "Action sheet action title", "primary")
+NSString *Localized(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nullable tableName);
 
 /// Additional localization function used to localize strings
 ///
-/// The `value` should be the English string, the `comment` should give context on where the string is used, and the `keyExtension` should
-/// be used to provide additional differentiation between contexts. The `keyExtension` is included when generating the string `key` so two
-/// calls with the same `value` but different `keyExtension` values will result in two different strings in the localization dictionary.
+/// @param value: The English string
+/// @param comment: String to give context where the value string is used
+/// @param keyExtension: String to be used to provide additional differentiation between contexts. The `keyExtension` is included when generating the string `key` so two calls with the same `value` but different `keyExtension` values will result in two different strings in the localization dictionary
+/// @param tableName: Optional string to provide additional classification of the string. Can be used to segment groups of strings in multiple bundles.
 ///
-/// Ex: `LocalizedWithKeyExtension("Archive", "Button title", "Archive action")
-/// Ex: `LocalizedWithKeyExtension("Archive", "Folder title", "Archive folder")
-NSString *LocalizedWithKeyExtension(NSString *value, NSString *comment, NSString *keyExtension);
+/// Ex: `LocalizedWithKeyExtension("Archive", "Button title", "Archive action", nil)
+/// Ex: `LocalizedWithKeyExtension("Archive", "Folder title", "Archive folder", nil)
+NSString *LocalizedWithKeyExtension(NSString *_Nonnull value, NSString *_Nonnull scomment, NSString *_Nonnull keyExtension, NSString *_Nullable tableName);
 
 /// Marks a string as not needing localization (to avoid false positives from
 /// the static analyzer
 NSString *LocalizationUnnecessary(NSString *value);
 
 /// Load the bundle which contains the localized strings
-NSBundle * _Nullable getLocalizedStringKitBundle(void);
+///
+/// @param tableName: Optional tableName to find related bundle for strings. tableNames can be used to segment localized string bundles. If nil, default bundle will be returned.
+NSBundle * _Nullable getLocalizedStringKitBundle(NSString *_Nullable tableName);
 
 NS_ASSUME_NONNULL_END

--- a/Sources/LocalizedStringKit/include/LocalizedStringKit.h
+++ b/Sources/LocalizedStringKit/include/LocalizedStringKit.h
@@ -12,17 +12,27 @@ FOUNDATION_EXPORT double LocalizedStringKitVersionNumber;
 //! Project version string for LocalizedStringKit.
 FOUNDATION_EXPORT const unsigned char LocalizedStringKitVersionString[];
 
+/// Primary localization function used to localize strings (excluding tableName)
+///
+/// @param value: The English string
+/// @param comment: String to give context where the value string is used
+///
+/// Examples
+/// Localized("Cancel", "Action sheet action title")
+NSString *Localized(NSString *_Nonnull value, NSString *_Nonnull comment);
+
+
 /// Primary localization function used to localize strings
 ///
 /// @param value: The English string
 /// @param comment: String to give context where the value string is used
-/// @param tableName: Optional string to provide additional classification of the value string. Can be used to segment groups of strings in multiple bundles.
+/// @param tableName: String to provide additional classification of the value string. Can be used to segment groups of strings in multiple bundles.
 ///
 /// Examples
 /// Localized("Cancel", "Action sheet action title", nil)
 /// Localized("Cancel", "Action sheet action title", "primary")
 /// Localized("Cancel", "Action sheet action title", "primary")
-NSString *Localized(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nullable tableName);
+NSString *LocalizedWithTable(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nonnull tableName);
 
 /// Additional localization function used to localize strings
 ///

--- a/Tests/LocalizedStringKitTests/LocalizedStringKitTests.swift
+++ b/Tests/LocalizedStringKitTests/LocalizedStringKitTests.swift
@@ -18,14 +18,14 @@ final class LocalizedStringKitTests: XCTestCase {
     func testExample() {
       // Note: if this test fails its likely the device was set to a none EN locale.
       if Locale.current.languageCode == "en" {
-        XCTAssertEqual(Localized("Done", "Done", nil), "Done")
-        XCTAssertEqual(Localized("Not a Localized String", "Done", nil), "Not a Localized String")
+        XCTAssertEqual(Localized("Done", "Done"), "Done")
+        XCTAssertEqual(Localized("Not a Localized String", "Done"), "Not a Localized String")
         XCTAssertEqual(LocalizationUnnecessary("Not Needed"), "Not Needed")
       }
       else {
         XCTFail("Please add other development language localization tests")
-        XCTAssertEqual(Localized("Done", "Done", nil), "Done")
-        XCTAssertEqual(Localized("Not a Localized String", "Done", nil), "Not a Localized String")
+        XCTAssertEqual(Localized("Done", "Done"), "Done")
+        XCTAssertEqual(LocalizedWithTable("Not a Localized String", "Done", "primary"), "Not a Localized String")
         XCTAssertEqual(LocalizationUnnecessary("Not Needed"), "Not Needed")
       }
     }

--- a/Tests/LocalizedStringKitTests/LocalizedStringKitTests.swift
+++ b/Tests/LocalizedStringKitTests/LocalizedStringKitTests.swift
@@ -18,14 +18,14 @@ final class LocalizedStringKitTests: XCTestCase {
     func testExample() {
       // Note: if this test fails its likely the device was set to a none EN locale.
       if Locale.current.languageCode == "en" {
-        XCTAssertEqual(Localized("Done", "Done"), "Done")
-        XCTAssertEqual(Localized("Not a Localized String", "Done"), "Not a Localized String")
+        XCTAssertEqual(Localized("Done", "Done", nil), "Done")
+        XCTAssertEqual(Localized("Not a Localized String", "Done", nil), "Not a Localized String")
         XCTAssertEqual(LocalizationUnnecessary("Not Needed"), "Not Needed")
       }
       else {
         XCTFail("Please add other development language localization tests")
-        XCTAssertEqual(Localized("Done", "Done"), "Done")
-        XCTAssertEqual(Localized("Not a Localized String", "Done"), "Not a Localized String")
+        XCTAssertEqual(Localized("Done", "Done", nil), "Done")
+        XCTAssertEqual(Localized("Not a Localized String", "Done", nil), "Not a Localized String")
         XCTAssertEqual(LocalizationUnnecessary("Not Needed"), "Not Needed")
       }
     }


### PR DESCRIPTION
## Changes
- Add support for multiple tableNames
- Update static cacheing to use dictionary for bundles rather than single bundle
- Update tests with new API signature
- Improve nullability annotations