### PR TITLE
API Improvements, Primary Bundle Name support, Alternate Search Path support

### DIFF
--- a/LocalizedStringKit.xcodeproj/project.pbxproj
+++ b/LocalizedStringKit.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		OBJ_15 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
 		OBJ_25 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		OBJ_9 /* LocalizedStringKit.m */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = LocalizedStringKit.m; sourceTree = "<group>"; tabWidth = 2; };
+		OBJ_9 /* LocalizedStringKit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LocalizedStringKit.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/LocalizedStringKit.xcodeproj/project.pbxproj
+++ b/LocalizedStringKit.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		OBJ_15 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
 		OBJ_25 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		OBJ_9 /* LocalizedStringKit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LocalizedStringKit.m; sourceTree = "<group>"; };
+		OBJ_9 /* LocalizedStringKit.m */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = LocalizedStringKit.m; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ ProjectName/
 |   ├── LocalizedStringKit.bundle/
 ```
 
-#### Secondary Bundle(s): tableNames
+#### Secondary Bundle(s): bundleNames
 
-To leverage the tableName segmentation of strings in multiple bundles, you'll need to create these bundles as well.
+To leverage the bundleName segmentation of strings in multiple bundles, you'll need to create these bundles as well.
 
 1. Navigate to the first `LocalizedStringKit` folder that was created in the Primary set up.
-2. Inside that folder, create a new folder named `<tableName>.bundle` (this will turn it into a bundle). Make sure to replace `tableName` with the case sensitive tableName you will use in your source.
+2. Inside that folder, create a new folder named `<bundleName>.bundle` (this will turn it into a bundle). Make sure to replace `bundleName` with the case sensitive bundleName you will use in your source.
 3. Add this bundle to your project in Xcode
 4. Ensure that this bundle is copied to your main app bundle (even if you are going to be using it in a framework).
 

--- a/Sources/LocalizedStringKit/LocalizedStringKit.m
+++ b/Sources/LocalizedStringKit/LocalizedStringKit.m
@@ -14,9 +14,9 @@
 
 #pragma mark - Public
 
-NSString *_Nonnull primaryBundleName = @"LocalizedStringKit.bundle";
+NSString *_Nonnull LSKPrimaryBundleName = @"LocalizedStringKit.bundle";
 
-NSURL *_Nullable alternateBundleSearchPath = nil;
+NSURL *_Nullable LSKAlternateBundleSearchPath = nil;
 
 NSString *Localized(NSString *_Nonnull value, NSString *_Nonnull comment) {
   return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:nil bundleName:nil];
@@ -113,7 +113,7 @@ NSBundle *getLocalizedStringKitBundle(NSString *_Nullable bundleName) {
   // Determine target bundleName
   if (bundleName == nil) {
     // Defaults to primary bundle if bundleName not specified
-    bundleName = primaryBundleName;
+    bundleName = LSKPrimaryBundleName;
   }
   else
   {
@@ -121,24 +121,24 @@ NSBundle *getLocalizedStringKitBundle(NSString *_Nullable bundleName) {
     bundleName = [bundleName stringByAppendingFormat:@".bundle"];
   }
 
+  // Alternate path check, if url specified
+  if (LSKAlternateBundleSearchPath != nil) {
+    NSURL *alternateBundleURL = [LSKAlternateBundleSearchPath URLByAppendingPathComponent:bundleName];
+    NSBundle *bundle = [NSBundle bundleWithURL:alternateBundleURL];
+    if (bundle) {
+      return bundle;
+    }
+  }
+
+  // Primary searchPath check
   while(YES)
   {
-    // Primary searchPath check
     NSURL *bundleURL = [searchPath URLByAppendingPathComponent:bundleName];
     NSBundle *bundle = [NSBundle bundleWithURL:bundleURL];
 
     if (bundle)
     {
       return bundle;
-    }
-
-    // Alternate path check, if url specified
-    if (alternateBundleSearchPath != nil) {
-      NSURL *alternateBundleURL = [alternateBundleSearchPath URLByAppendingPathComponent:bundleName];
-      NSBundle *bundle = [NSBundle bundleWithURL:alternateBundleURL];
-      if (bundle) {
-        return bundle;
-      }
     }
 
     NSURL *newPath = [[searchPath URLByAppendingPathComponent:@".."] absoluteURL];

--- a/Sources/LocalizedStringKit/LocalizedStringKit.m
+++ b/Sources/LocalizedStringKit/LocalizedStringKit.m
@@ -14,16 +14,20 @@
 
 #pragma mark - Public
 
+NSString *_Nonnull primaryBundleName = @"LocalizedStringKit.bundle";
+
+NSURL *_Nullable alternateBundleSearchPath = nil;
+
 NSString *Localized(NSString *_Nonnull value, NSString *_Nonnull comment) {
-  return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:nil tableName:nil];
+  return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:nil bundleName:nil];
 }
 
-NSString *LocalizedWithTable(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nonnull tableName) {
-  return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:nil tableName:tableName];
+NSString *LocalizedWithBundle(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nonnull bundleName) {
+  return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:nil bundleName:bundleName];
 }
 
-NSString *LocalizedWithKeyExtension(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nonnull keyExtension, NSString *_Nullable tableName) {
-  return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:keyExtension tableName:tableName];
+NSString *LocalizedWithKeyExtension(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nonnull keyExtension, NSString *_Nullable bundleName) {
+  return [LocalizedStringKit localizeWithValue:value comment:comment keyExtension:keyExtension bundleName:bundleName];
 }
 
 __attribute__((annotate("returns_localized_nsstring")))
@@ -31,13 +35,13 @@ NSString *LocalizationUnnecessary(NSString *value) {
   return value;
 }
 
-NSBundle *getLocalizedStringKitBundle(NSString *_Nullable tableName) {
-  return [LocalizedStringKit getLocalizedStringKitBundle:tableName];
+NSBundle *getLocalizedStringKitBundle(NSString *_Nullable bundleName) {
+  return [LocalizedStringKit getLocalizedStringKitBundle:bundleName];
 }
 
 #pragma mark - Private / Static
 
-+ (NSString *)localizeWithValue:(NSString *_Nonnull)value comment:(NSString *_Nonnull)comment keyExtension:(NSString *_Nullable)keyExtension tableName:(NSString *_Nullable)tableName
++ (NSString *)localizeWithValue:(NSString *_Nonnull)value comment:(NSString *_Nonnull)comment keyExtension:(NSString *_Nullable)keyExtension bundleName:(NSString *_Nullable)bundleName
 {
   // Key
   NSString *key = [self keyWithValue:value keyExtension:keyExtension];
@@ -45,26 +49,26 @@ NSBundle *getLocalizedStringKitBundle(NSString *_Nullable tableName) {
   // Table: This does not change between bundles
   NSString *table = @"LocalizedStringKit";
 
-  // Bundle Map: [tableName String: NSBundle]
+  // Bundle Map: [bundleName String: NSBundle]
   static NSMutableDictionary<NSString *, NSBundle *> *bundleMap = nil;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     bundleMap = [[NSMutableDictionary alloc] init];
   });
 
-  if (tableName == nil)
+  if (bundleName == nil)
   {
     // Default to primary strings bundle
-    tableName = @"LocalizedStringKit.bundle";
+    bundleName = @"LocalizedStringKit.bundle";
   }
 
-  NSBundle *bundle = [bundleMap objectForKey:tableName];
+  NSBundle *bundle = [bundleMap objectForKey:bundleName];
 
   if (bundle == nil)
   {
     // Load and cache bundle
-    bundle = [LocalizedStringKit getLocalizedStringKitBundle:tableName];
-    [bundleMap setObject:bundle forKey:tableName];
+    bundle = [LocalizedStringKit getLocalizedStringKitBundle:bundleName];
+    [bundleMap setObject:bundle forKey:bundleName];
   }
 
   if (bundle == nil)
@@ -101,28 +105,40 @@ NSBundle *getLocalizedStringKitBundle(NSString *_Nullable tableName) {
   return key;
 }
 
-+ (NSBundle *)getLocalizedStringKitBundle:(NSString *_Nullable)tableName
++ (NSBundle *)getLocalizedStringKitBundle:(NSString *_Nullable)bundleName
 {
+  // Search Paths
   NSURL *searchPath = [[NSBundle mainBundle] bundleURL];
 
-  if (tableName == nil) {
-    // Defaults to primary bundle if tableName not specified
-    tableName = @"LocalizedStringKit.bundle";
+  // Determine target bundleName
+  if (bundleName == nil) {
+    // Defaults to primary bundle if bundleName not specified
+    bundleName = primaryBundleName;
   }
   else
   {
     // Append suffix
-    tableName = [tableName stringByAppendingFormat:@".bundle"];
+    bundleName = [bundleName stringByAppendingFormat:@".bundle"];
   }
 
   while(YES)
   {
-    NSURL *bundleURL = [searchPath URLByAppendingPathComponent:tableName];
+    // Primary searchPath check
+    NSURL *bundleURL = [searchPath URLByAppendingPathComponent:bundleName];
     NSBundle *bundle = [NSBundle bundleWithURL:bundleURL];
 
     if (bundle)
     {
       return bundle;
+    }
+
+    // Alternate path check, if url specified
+    if (alternateBundleSearchPath != nil) {
+      NSURL *alternateBundleURL = [alternateBundleSearchPath URLByAppendingPathComponent:bundleName];
+      NSBundle *bundle = [NSBundle bundleWithURL:alternateBundleURL];
+      if (bundle) {
+        return bundle;
+      }
     }
 
     NSURL *newPath = [[searchPath URLByAppendingPathComponent:@".."] absoluteURL];

--- a/Sources/LocalizedStringKit/include/LocalizedStringKit.h
+++ b/Sources/LocalizedStringKit/include/LocalizedStringKit.h
@@ -18,7 +18,7 @@ FOUNDATION_EXPORT const unsigned char LocalizedStringKitVersionString[];
 FOUNDATION_EXPORT NSString *_Nonnull primaryBundleName;
 
 /// URL for alternate string bundle search (the root from where search will begin)
-FOUNDATION_EXPORT NSURL *_Nullable alternateBundleSearchPath;
+FOUNDATION_EXPORT NSURL *_Nullable LSKAlternateBundleSearchPath;
 
 /// Primary localization function used to localize strings (excluding bundleName)
 ///

--- a/Sources/LocalizedStringKit/include/LocalizedStringKit.h
+++ b/Sources/LocalizedStringKit/include/LocalizedStringKit.h
@@ -12,7 +12,15 @@ FOUNDATION_EXPORT double LocalizedStringKitVersionNumber;
 //! Project version string for LocalizedStringKit.
 FOUNDATION_EXPORT const unsigned char LocalizedStringKitVersionString[];
 
-/// Primary localization function used to localize strings (excluding tableName)
+/// The name to be used for the primary strings bundle
+/// Example:
+/// "Localizable" (do not include the extension suffix)
+FOUNDATION_EXPORT NSString *_Nonnull primaryBundleName;
+
+/// URL for alternate string bundle search (the root from where search will begin)
+FOUNDATION_EXPORT NSURL *_Nullable alternateBundleSearchPath;
+
+/// Primary localization function used to localize strings (excluding bundleName)
 ///
 /// @param value: The English string
 /// @param comment: String to give context where the value string is used
@@ -26,24 +34,24 @@ NSString *Localized(NSString *_Nonnull value, NSString *_Nonnull comment);
 ///
 /// @param value: The English string
 /// @param comment: String to give context where the value string is used
-/// @param tableName: String to provide additional classification of the value string. Can be used to segment groups of strings in multiple bundles.
+/// @param bundleName: String to provide additional classification of the value string. Can be used to segment groups of strings in multiple bundles.
 ///
 /// Examples
 /// Localized("Cancel", "Action sheet action title", nil)
 /// Localized("Cancel", "Action sheet action title", "primary")
 /// Localized("Cancel", "Action sheet action title", "primary")
-NSString *LocalizedWithTable(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nonnull tableName);
+NSString *LocalizedWithBundle(NSString *_Nonnull value, NSString *_Nonnull comment, NSString *_Nonnull bundleName);
 
 /// Additional localization function used to localize strings
 ///
 /// @param value: The English string
 /// @param comment: String to give context where the value string is used
 /// @param keyExtension: String to be used to provide additional differentiation between contexts. The `keyExtension` is included when generating the string `key` so two calls with the same `value` but different `keyExtension` values will result in two different strings in the localization dictionary
-/// @param tableName: Optional string to provide additional classification of the string. Can be used to segment groups of strings in multiple bundles.
+/// @param bundleName: Optional string to provide additional classification of the string. Can be used to segment groups of strings in multiple bundles.
 ///
 /// Ex: `LocalizedWithKeyExtension("Archive", "Button title", "Archive action", nil)
 /// Ex: `LocalizedWithKeyExtension("Archive", "Folder title", "Archive folder", nil)
-NSString *LocalizedWithKeyExtension(NSString *_Nonnull value, NSString *_Nonnull scomment, NSString *_Nonnull keyExtension, NSString *_Nullable tableName);
+NSString *LocalizedWithKeyExtension(NSString *_Nonnull value, NSString *_Nonnull scomment, NSString *_Nonnull keyExtension, NSString *_Nullable bundleName);
 
 /// Marks a string as not needing localization (to avoid false positives from
 /// the static analyzer
@@ -51,7 +59,7 @@ NSString *LocalizationUnnecessary(NSString *value);
 
 /// Load the bundle which contains the localized strings
 ///
-/// @param tableName: Optional tableName to find related bundle for strings. tableNames can be used to segment localized string bundles. If nil, default bundle will be returned.
-NSBundle * _Nullable getLocalizedStringKitBundle(NSString *_Nullable tableName);
+/// @param bundleName: Optional bundleName to find related bundle for strings. bundleNames can be used to segment localized string bundles. If nil, default bundle will be returned.
+NSBundle * _Nullable getLocalizedStringKitBundle(NSString *_Nullable bundleName);
 
 NS_ASSUME_NONNULL_END

--- a/Sources/LocalizedStringKit/include/LocalizedStringKit.h
+++ b/Sources/LocalizedStringKit/include/LocalizedStringKit.h
@@ -60,6 +60,6 @@ NSString *LocalizationUnnecessary(NSString *value);
 /// Load the bundle which contains the localized strings
 ///
 /// @param bundleName: Optional bundleName to find related bundle for strings. bundleNames can be used to segment localized string bundles. If nil, default bundle will be returned.
-NSBundle * _Nullable getLocalizedStringKitBundle(NSString *_Nullable bundleName);
+NSBundle * _Nullable LSKLocalizedStringKitBundle(NSString *_Nullable bundleName);
 
 NS_ASSUME_NONNULL_END

--- a/Sources/LocalizedStringKit/include/LocalizedStringKit.h
+++ b/Sources/LocalizedStringKit/include/LocalizedStringKit.h
@@ -15,7 +15,7 @@ FOUNDATION_EXPORT const unsigned char LocalizedStringKitVersionString[];
 /// The name to be used for the primary strings bundle
 /// Example:
 /// "Localizable" (do not include the extension suffix)
-FOUNDATION_EXPORT NSString *_Nonnull primaryBundleName;
+FOUNDATION_EXPORT NSString *_Nonnull LSKPrimaryBundleName;
 
 /// URL for alternate string bundle search (the root from where search will begin)
 FOUNDATION_EXPORT NSURL *_Nullable LSKAlternateBundleSearchPath;

--- a/Tests/LocalizedStringKitTests/LocalizedStringKitTests.swift
+++ b/Tests/LocalizedStringKitTests/LocalizedStringKitTests.swift
@@ -25,7 +25,7 @@ final class LocalizedStringKitTests: XCTestCase {
       else {
         XCTFail("Please add other development language localization tests")
         XCTAssertEqual(Localized("Done", "Done"), "Done")
-        XCTAssertEqual(LocalizedWithTable("Not a Localized String", "Done", "primary"), "Not a Localized String")
+        XCTAssertEqual(LocalizedWithBundle("Not a Localized String", "Done", "primary"), "Not a Localized String")
         XCTAssertEqual(LocalizationUnnecessary("Not Needed"), "Not Needed")
       }
     }


### PR DESCRIPTION
API Improvements, Primary Bundle Name support, Alternate Search Path support

- Update tableName to bundleName for improved readability
- Expose primaryBundleName string to allow override of primary bundle name.
- Expose nullable alternateSearchPathURL to allow for searching of bundles in other locations (other than main app bundle)
- Docstrings added for relevant changes