### PR TITLE
Add .bundle string inclusion check

### DIFF
--- a/Sources/LocalizedStringKit/LocalizedStringKit.m
+++ b/Sources/LocalizedStringKit/LocalizedStringKit.m
@@ -115,7 +115,7 @@ NSBundle *getLocalizedStringKitBundle(NSString *_Nullable bundleName) {
     // Defaults to primary bundle if bundleName not specified
     bundleName = LSKPrimaryBundleName;
   }
-  else if ([bundleName rangeOfString:@".bundle"].location == NSNotFound)
+  else if (![bundleName hasSuffix:@".bundle"])
   {
     // Append suffix
     bundleName = [bundleName stringByAppendingFormat:@".bundle"];

--- a/Sources/LocalizedStringKit/LocalizedStringKit.m
+++ b/Sources/LocalizedStringKit/LocalizedStringKit.m
@@ -115,7 +115,7 @@ NSBundle *getLocalizedStringKitBundle(NSString *_Nullable bundleName) {
     // Defaults to primary bundle if bundleName not specified
     bundleName = LSKPrimaryBundleName;
   }
-  else
+  else if ([bundleName rangeOfString:@".bundle"].location == NSNotFound)
   {
     // Append suffix
     bundleName = [bundleName stringByAppendingFormat:@".bundle"];


### PR DESCRIPTION
Adding check for `.bundle` in bundleName string to avoid duplicate appendage if it already exists