### PR TITLE
Preserve comment order as before

### DIFF
--- a/generation/localizedstringkit/__init__.py
+++ b/generation/localizedstringkit/__init__.py
@@ -259,7 +259,7 @@ def _write_strings_file(output_directory: str, strings: List[Any]) -> None:
             for key in sorted(entries_by_key.keys()):
                 entry = entries_by_key[key]
                 # Sort comments alphabetically
-                entry.comments.sort()
+                entry.comments.sort(key=str.lower)
                 strings_file.write(entry.strings_format())
                 strings_file.write("\n\n")
 

--- a/generation/pyproject.toml
+++ b/generation/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "localizedstringkit"
-version = "0.3.0"
+version = "0.3.1"
 description = "Generate .strings files directly from your code"
 authors = ["Dale Myers <dalemy@microsoft.com>"]
 license = "MIT"


### PR DESCRIPTION
#42 change the comment order to ASCII order (case sensitive), this would break the existing comment order (case in-sensitive), this PR changes the order to Preserve comment order as before. to minimize the breaking changes after ingestion 0.3.0