### PR TITLE
Improve file discovery time cost

### DIFF
--- a/generation/localizedstringkit/files.py
+++ b/generation/localizedstringkit/files.py
@@ -1,12 +1,34 @@
 """Utilities for dealing with localized strings."""
 
 import os
+import shutil
 import subprocess
 from typing import List, Optional
 
 from localizedstringkit import logger
 
 log = logger.get()
+
+
+def _is_ripgrep_available() -> bool:
+    """Check if ripgrep is available on the system."""
+
+    return shutil.which("rg") is not None
+
+
+def _build_ripgrep_command(root_path: str, excluded_folders: List[str]) -> List[str]:
+    """Build a ripgrep command to find source files."""
+
+    rg_cmd = ["rg", "--files", "--glob", "*.swift", "--glob", "*.m"]
+
+    for folder in excluded_folders:
+        # Convert absolute path to relative path for ripgrep glob
+        rel_path = os.path.relpath(folder, root_path).rstrip(os.sep)
+        # Exclude the directory and all its contents
+        rg_cmd.extend(["--glob", f"!{rel_path}/"])
+
+    rg_cmd.append(root_path)
+    return rg_cmd
 
 
 def _build_find_command(root_path: str, excluded_folders: List[str]) -> List[str]:
@@ -32,6 +54,7 @@ def localizable_files(
     root_path: str,
     excluded_folders: Optional[List[str]] = None,
     exclusion_file_path: Optional[str] = None,
+    use_ripgrep: bool = False,
 ) -> List[str]:
     """Find all source files which should be processed.
 
@@ -50,6 +73,10 @@ def localizable_files(
                                               absolute path. _Note:_ Only this
                                               OR `excluded_folders` should be
                                               set.
+    :param bool use_ripgrep: Whether to use ripgrep for finding files.
+                             If False, the find command will be used.
+                             If True, ripgrep will be used if it is available,
+                             otherwise the find command will be used.
 
     :raises ValueError: If neither excluded_folders nor exclusion_file_path is set.
     :raise CalledProcessError: If the find command fails.
@@ -75,15 +102,16 @@ def localizable_files(
 
     log.debug("Fetching localizable files")
 
+    if use_ripgrep and _is_ripgrep_available():
+        cmd = _build_ripgrep_command(root_path=root_path, excluded_folders=excluded_folders)
+        log.debug("Using ripgrep command: %s", cmd)
+    else:
+        cmd = _build_find_command(root_path=root_path, excluded_folders=excluded_folders)
+        log.debug("Using find command: %s", cmd)
+
     results = []
-
-    # Prune excluded directories in find to reduce traversal work.
-    find_cmd = _build_find_command(root_path=root_path, excluded_folders=excluded_folders)
-
-    log.debug("Running find command: %s", find_cmd)
-
     with subprocess.Popen(
-        find_cmd,
+        cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
@@ -93,6 +121,8 @@ def localizable_files(
         for line in process.stdout:
             file_path = line.rstrip("\n")
             if file_path:
+                if not os.path.isabs(file_path):
+                    file_path = os.path.join(root_path, file_path)
                 results.append(file_path)
 
         return_code = process.wait()
@@ -100,7 +130,7 @@ def localizable_files(
             stderr = ""
             if process.stderr is not None:
                 stderr = process.stderr.read()
-            raise subprocess.CalledProcessError(return_code, find_cmd, stderr=stderr)
+            raise subprocess.CalledProcessError(return_code, cmd, stderr=stderr)
 
     results.sort()
     return results

--- a/generation/pyproject.toml
+++ b/generation/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "localizedstringkit"
-version = "0.3.1"
+version = "0.3.2"
 description = "Generate .strings files directly from your code"
 authors = ["Dale Myers <dalemy@microsoft.com>"]
 license = "MIT"


### PR DESCRIPTION
This PR adds the support to use [ripgrep](https://github.com/BurntSushi/ripgrep) to get localizable files.

time cost comparasion:
ripgrep: 180ms
find: 9.2s