### PR TITLE
Fix runtime hash truncation and guard bundleMap access

### DIFF
--- a/Sources/LocalizedStringKit/LocalizedStringKit.m
+++ b/Sources/LocalizedStringKit/LocalizedStringKit.m
@@ -3,6 +3,7 @@
 //
 
 @import CommonCrypto;
+#import <os/lock.h>
 
 #import "LocalizedStringKit.h"
 
@@ -13,6 +14,11 @@
 @implementation LocalizedStringKit
 
 static NSMutableDictionary *bundleMap = nil;
+
+// Guards all access to `bundleMap`. `dispatch_once` only guards initialization,
+// not the subsequent reads/mutations, so concurrent `Localized()` calls would
+// otherwise race on the dictionary.
+static os_unfair_lock bundleMapLock = OS_UNFAIR_LOCK_INIT;
 
 #pragma mark - Public
 
@@ -45,6 +51,10 @@ NSBundle * _Nullable getLocalizedStringKitBundle(NSString *_Nullable bundleName)
   return [LocalizedStringKit getLocalizedStringKitBundle:bundleName];
 }
 
+NSString *_Nonnull LSKKeyForValue(NSString *_Nonnull value, NSString *_Nullable keyExtension) {
+  return [LocalizedStringKit keyWithValue:value keyExtension:keyExtension];
+}
+
 #pragma mark - Private / Static
 
 + (NSString *)localizeWithValue:(NSString *_Nonnull)value comment:(NSString *_Nonnull)comment keyExtension:(NSString *_Nullable)keyExtension bundleName:(NSString *_Nullable)bundleName
@@ -67,7 +77,11 @@ NSBundle * _Nullable getLocalizedStringKitBundle(NSString *_Nullable bundleName)
     bundleName = LSKPrimaryBundleName;
   }
 
-  NSBundle *bundle = [bundleMap objectForKey:bundleName];
+  NSBundle *bundle = nil;
+
+  os_unfair_lock_lock(&bundleMapLock);
+
+  bundle = [bundleMap objectForKey:bundleName];
 
   if (bundle == nil)
   {
@@ -77,10 +91,13 @@ NSBundle * _Nullable getLocalizedStringKitBundle(NSString *_Nullable bundleName)
     {
       [bundleMap setObject:[NSNull null] forKey:bundleName];
       // Unable to load `LocalizedStringKit` bundle
+      os_unfair_lock_unlock(&bundleMapLock);
       return value;
     }
     [bundleMap setObject:bundle forKey:bundleName];
   }
+
+  os_unfair_lock_unlock(&bundleMapLock);
 
   if ([bundle isKindOfClass:[NSNull class]]) {
     // Resolved NSNull for bundle
@@ -104,7 +121,11 @@ NSBundle * _Nullable getLocalizedStringKitBundle(NSString *_Nullable bundleName)
   const char *inputCharacterArray = [hashInput UTF8String];
   unsigned char outputCharacterArray[CC_MD5_DIGEST_LENGTH];
 
-  CC_MD5(inputCharacterArray, (CC_LONG)strnlen(inputCharacterArray, sizeof inputCharacterArray), outputCharacterArray);
+  // Hash the full UTF-8 byte length of the string. Note: `sizeof inputCharacterArray`
+  // is the size of the pointer (8 bytes on 64-bit), not the string length, so it must
+  // not be used to bound the hash input or the key would only cover the first 8 bytes.
+  // This must stay in sync with the generator, which hashes the full string.
+  CC_MD5(inputCharacterArray, (CC_LONG)[hashInput lengthOfBytesUsingEncoding:NSUTF8StringEncoding], outputCharacterArray);
 
   NSMutableString *key = [[NSMutableString alloc] init];
 
@@ -174,7 +195,9 @@ void LSKSetPrimaryBundleName(NSString *_Nonnull bundleName) {
 
 void LSKSetAlternateBundleSearchPath(NSURL *_Nonnull url) {
   LSKAlternateBundleSearchPath = url;
+  os_unfair_lock_lock(&bundleMapLock);
   [bundleMap removeAllObjects];
+  os_unfair_lock_unlock(&bundleMapLock);
 }
 
 @end

--- a/Sources/LocalizedStringKit/include/LocalizedStringKit.h
+++ b/Sources/LocalizedStringKit/include/LocalizedStringKit.h
@@ -86,4 +86,15 @@ void LSKSetAlternateBundleSearchPath(NSURL *_Nonnull url);
 /// @param bundleName Name of bundle to search for
 NSBundle * _Nullable getLocalizedStringKitBundle(NSString *_Nullable bundleName);
 
+/// Compute the localization key for a value (and optional key extension).
+///
+/// The key is the hex-encoded MD5 of the full UTF-8 value, or of
+/// `<value>:<keyExtension>` when a non-empty key extension is supplied. This is
+/// the exact key used for runtime lookups and must match the key produced by
+/// the generation tool.
+///
+/// @param value The English string
+/// @param keyExtension Optional key extension used to disambiguate homographs
+NSString *_Nonnull LSKKeyForValue(NSString *_Nonnull value, NSString *_Nullable keyExtension);
+
 NS_ASSUME_NONNULL_END

--- a/Tests/LocalizedStringKitTests/LocalizedStringKitTests.swift
+++ b/Tests/LocalizedStringKitTests/LocalizedStringKitTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import XCTest
 @testable import LocalizedStringKit
 
@@ -59,6 +60,32 @@ final class LocalizedStringKitTests: XCTestCase {
         XCTAssertNil(getLocalizedStringKitBundle("unknown_bundle"))
     }
 
+    /// Regression test for the runtime hash truncation bug. The runtime must
+    /// hash the *full* UTF-8 string, not just the first 8 bytes, so that the
+    /// key matches the one produced by the generation tool.
+    func testKeyForValueMatchesFullStringHash() {
+      // A value longer than 8 bytes. The pre-fix implementation truncated the
+      // hash input to the pointer size (8 bytes), producing the wrong key.
+      let value = "Terms and Conditions"
+      XCTAssertEqual(LSKKeyForValue(value, nil), Self.md5Hex(value))
+    }
+
+    /// Two values that share their first 8 bytes must produce different keys.
+    func testKeyForValueDistinguishesLongStringsSharingPrefix() {
+      let keyA = LSKKeyForValue("Settings screen", nil)
+      let keyB = LSKKeyForValue("Settings menu", nil)
+      XCTAssertNotEqual(keyA, keyB)
+    }
+
+    /// The key extension must be included in the hash input.
+    func testKeyForValueIncludesKeyExtension() {
+      let base = LSKKeyForValue("Schedule", nil)
+      let noun = LSKKeyForValue("Schedule", "Noun")
+      let verb = LSKKeyForValue("Schedule", "Verb")
+      XCTAssertNotEqual(base, noun)
+      XCTAssertNotEqual(noun, verb)
+    }
+
     func testPrimaryBundleName() {
       XCTAssertEqual(LSKPrimaryBundleName, "LocalizedStringKit.bundle")
       LSKSetPrimaryBundleName("Other.bundle")
@@ -88,4 +115,11 @@ final class LocalizedStringKitTests: XCTestCase {
     static var allTests = [
         ("testExample", testExample, testPrimaryBundleName, testAlternateBundleSearchPath),
     ]
+
+    /// Compute the hex-encoded MD5 of a string's UTF-8 bytes, matching the
+    /// generation tool's key algorithm.
+    static func md5Hex(_ string: String) -> String {
+      let digest = Insecure.MD5.hash(data: Data(string.utf8))
+      return digest.map { String(format: "%02x", $0) }.joined()
+    }
 }


### PR DESCRIPTION
## Summary

Two correctness/safety fixes to the Objective-C runtime, plus regression tests.

### 1. Runtime hash truncation (HIGH)
The runtime key hash used `strnlen(inputCharacterArray, sizeof inputCharacterArray)`. Since `inputCharacterArray` is a `const char *`, `sizeof` yields the **pointer size (8 bytes)**, not the string length — so only the first 8 UTF-8 bytes were hashed.

For any English string longer than 8 bytes, the runtime key no longer matched the full-string key produced by the generation tool, so `NSLocalizedStringWithDefaultValue` missed and silently fell back to the English default. It also caused runtime key collisions between strings sharing their first 8 bytes. Regressed in `3551089` (Nov 2021); the prior implementation used `strlen`.

Fixed by hashing the full UTF-8 byte length via `lengthOfBytesUsingEncoding:NSUTF8StringEncoding`.

### 2. `bundleMap` thread-safety (HIGH)
`bundleMap` was read and mutated without synchronization; `dispatch_once` only guarded initialization. Concurrent `Localized()` calls could race and corrupt/crash the dictionary. All access is now guarded by an `os_unfair_lock`.

### Tests
Exposed `LSKKeyForValue(value, keyExtension)` and added Swift regression tests asserting:
- the runtime key equals the full-string MD5 for a >8-byte value (catches the truncation bug),
- two values sharing their first 8 bytes get distinct keys,
- the key extension participates in the hash.

All 9 Swift tests pass via `swift test`.

> Note: this restores the correct (full-string) runtime keys, which already match the shipped `.strings` files — it's a fix, not a key rotation.